### PR TITLE
#4 Getting polls results

### DIFF
--- a/src/main/java/ru/hutoroff/jagpb/bot/commands/Command.java
+++ b/src/main/java/ru/hutoroff/jagpb/bot/commands/Command.java
@@ -1,12 +1,10 @@
 package ru.hutoroff.jagpb.bot.commands;
 
 import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Options;
 import ru.hutoroff.jagpb.bot.exceptions.UnknownCommandException;
 import ru.hutoroff.jagpb.bot.exceptions.UnknownOptionsException;
 
 public abstract class Command {
-    protected final static Options options = new Options();
     
     private final CommandType type;
     private final CommandLine arguments;
@@ -26,10 +24,6 @@ public abstract class Command {
         } else {
             this.arguments = null;
         }
-    }
-
-    public static Options getOptions() {
-        return options;
     }
 
     public CommandType getType() {

--- a/src/main/java/ru/hutoroff/jagpb/bot/commands/CommandBuilder.java
+++ b/src/main/java/ru/hutoroff/jagpb/bot/commands/CommandBuilder.java
@@ -1,6 +1,7 @@
 package ru.hutoroff.jagpb.bot.commands;
 
 import org.springframework.stereotype.Service;
+import ru.hutoroff.jagpb.bot.commands.implementation.*;
 import ru.hutoroff.jagpb.bot.exceptions.UnknownCommandException;
 import ru.hutoroff.jagpb.bot.exceptions.UnknownOptionsException;
 
@@ -19,20 +20,26 @@ public class CommandBuilder {
 		CommandType commandType = CommandType.getByCommand(split[0]);
 
 		switch (commandType) {
-			case START:
-				return new StartCommand();
-			case CREATE_POLL:
-				if (CreatePollCommand.REQUIRED_OPTIONS_NUMBER > (split.length -1)) {
-					return new CommandHelpCommand(split[0]);
-				}
-				return new CreatePollCommand(commandType, Arrays.copyOfRange(split, 1, split.length));
 			case COMMAND_HELP:
 				if (split.length == 1) {
 					return new CommandHelpCommand(split[0]);
 				}
 				return new CommandHelpCommand(split[1]);
+			case CREATE_POLL:
+				if (CreatePollCommand.REQUIRED_OPTIONS_NUMBER > (split.length -1)) {
+					return new CommandHelpCommand(split[0]);
+				}
+				return new CreatePollCommand(Arrays.copyOfRange(split, 1, split.length));
 			case HELP:
 				return new HelpCommand();
+			case LAST_POLL_RESULT:
+				if (split.length == 1) {
+					return new LastPollResultCommand(null);
+				} else {
+					return new LastPollResultCommand(Arrays.copyOfRange(split, 1, split.length));
+				}
+			case START:
+				return new StartCommand();
 		}
 		throw new IllegalArgumentException("Command '" + command + "' can not be executed");
 	}

--- a/src/main/java/ru/hutoroff/jagpb/bot/commands/CommandType.java
+++ b/src/main/java/ru/hutoroff/jagpb/bot/commands/CommandType.java
@@ -6,10 +6,11 @@ import java.util.Arrays;
 import java.util.Optional;
 
 public enum CommandType {
-    START("/start"),
+    COMMAND_HELP("/commandHelp"),
     CREATE_POLL("/create"),
     HELP("/help"),
-    COMMAND_HELP("/commandHelp");
+    LAST_POLL_RESULT("/lastPollResult"),
+    START("/start");
 
     String commandText;
 

--- a/src/main/java/ru/hutoroff/jagpb/bot/commands/Help.java
+++ b/src/main/java/ru/hutoroff/jagpb/bot/commands/Help.java
@@ -2,9 +2,10 @@ package ru.hutoroff.jagpb.bot.commands;
 
 public class Help {
 
-	static final String COMMAND_HELP_COMMAND = "usage: /commandHelp COMMAND";
-	static final String CREATE_POLL_COMMAND = "usage: /create -t \"Poll Title\" -o {\"option1\",\"option2\",...,\"optionN\"}";
-	static final String HELP = "usage: /help";
-	static final String START_COMMAND = "usage: /start";
+	public static final String COMMAND_HELP_COMMAND = "usage: /commandHelp COMMAND";
+	public static final String CREATE_POLL_COMMAND = "usage: /create -t \"Poll Title\" -o {\"option1\",\"option2\",...,\"optionN\"}";
+	public static final String HELP = "usage: /help";
+	public static final String LAST_POLL = "usage: /lastPollResult [-c \"CHAT_ID\"]";
+	public static final String START_COMMAND = "usage: /start";
 
 }

--- a/src/main/java/ru/hutoroff/jagpb/bot/commands/Help.java
+++ b/src/main/java/ru/hutoroff/jagpb/bot/commands/Help.java
@@ -5,7 +5,7 @@ public class Help {
 	public static final String COMMAND_HELP_COMMAND = "usage: /commandHelp COMMAND";
 	public static final String CREATE_POLL_COMMAND = "usage: /create -t \"Poll Title\" -o {\"option1\",\"option2\",...,\"optionN\"}";
 	public static final String HELP = "usage: /help";
-	public static final String LAST_POLL = "usage: /lastPollResult [-c \"CHAT_ID\"]";
+	public static final String LAST_POLL = "usage: /lastPollResult [[-c \"CHAT_ID\"]]";
 	public static final String START_COMMAND = "usage: /start";
 
 }

--- a/src/main/java/ru/hutoroff/jagpb/bot/commands/implementation/CommandHelpCommand.java
+++ b/src/main/java/ru/hutoroff/jagpb/bot/commands/implementation/CommandHelpCommand.java
@@ -1,6 +1,9 @@
-package ru.hutoroff.jagpb.bot.commands;
+package ru.hutoroff.jagpb.bot.commands.implementation;
 
 import org.apache.commons.cli.CommandLine;
+import ru.hutoroff.jagpb.bot.commands.Command;
+import ru.hutoroff.jagpb.bot.commands.CommandType;
+import ru.hutoroff.jagpb.bot.commands.Help;
 import ru.hutoroff.jagpb.bot.exceptions.UnknownCommandException;
 import ru.hutoroff.jagpb.bot.exceptions.UnknownOptionsException;
 
@@ -30,12 +33,16 @@ public class CommandHelpCommand extends Command {
 
 	public String getRequestedHelp() {
 		switch (this.commandTypeToHelp) {
-			case START:
-				return Help.START_COMMAND;
 			case COMMAND_HELP:
 				return Help.COMMAND_HELP_COMMAND;
 			case CREATE_POLL:
 				return Help.CREATE_POLL_COMMAND;
+			case HELP:
+				return Help.HELP;
+			case LAST_POLL_RESULT:
+				return Help.LAST_POLL;
+			case START:
+				return Help.START_COMMAND;
 		}
 		return "Unknown command";
 	}

--- a/src/main/java/ru/hutoroff/jagpb/bot/commands/implementation/CreatePollCommand.java
+++ b/src/main/java/ru/hutoroff/jagpb/bot/commands/implementation/CreatePollCommand.java
@@ -1,17 +1,19 @@
-package ru.hutoroff.jagpb.bot.commands;
+package ru.hutoroff.jagpb.bot.commands.implementation;
 
 import org.apache.commons.cli.*;
+import ru.hutoroff.jagpb.bot.commands.Command;
+import ru.hutoroff.jagpb.bot.commands.CommandType;
 import ru.hutoroff.jagpb.bot.exceptions.UnknownOptionsException;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
 public class CreatePollCommand extends Command {
-    private static final CommandLineParser cliParser = new DefaultParser();
-    private static final HelpFormatter helpFormatter = new HelpFormatter();
     public static final int REQUIRED_OPTIONS_NUMBER = 2;
+    private static final CommandLineParser cliParser = new DefaultParser();
     private static final String COMMAND_SYNTAX = "/create -t \"Poll Title\" -o {\"option1\",\"option2\",...,\"optionN\"}";
     private static final String HELP;
+    private static final Options options = new Options();
 
     static {
         options.addOption(Option.builder("t")
@@ -38,12 +40,13 @@ public class CreatePollCommand extends Command {
 
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);
+        HelpFormatter helpFormatter = new HelpFormatter();
         helpFormatter.printHelp(pw, HelpFormatter.DEFAULT_WIDTH, COMMAND_SYNTAX, null, options, 3,0,null);
         HELP = sw.toString();
     }
 
-    public CreatePollCommand(CommandType type, String[] arguments) throws UnknownOptionsException {
-        super(type, arguments);
+    public CreatePollCommand(String[] arguments) throws UnknownOptionsException {
+        super(CommandType.CREATE_POLL, arguments);
     }
 
     @Override

--- a/src/main/java/ru/hutoroff/jagpb/bot/commands/implementation/HelpCommand.java
+++ b/src/main/java/ru/hutoroff/jagpb/bot/commands/implementation/HelpCommand.java
@@ -1,6 +1,9 @@
-package ru.hutoroff.jagpb.bot.commands;
+package ru.hutoroff.jagpb.bot.commands.implementation;
 
 import org.apache.commons.cli.CommandLine;
+import ru.hutoroff.jagpb.bot.commands.Command;
+import ru.hutoroff.jagpb.bot.commands.CommandType;
+import ru.hutoroff.jagpb.bot.commands.Help;
 import ru.hutoroff.jagpb.bot.exceptions.UnknownOptionsException;
 
 public class HelpCommand extends Command {

--- a/src/main/java/ru/hutoroff/jagpb/bot/commands/implementation/LastPollResultCommand.java
+++ b/src/main/java/ru/hutoroff/jagpb/bot/commands/implementation/LastPollResultCommand.java
@@ -1,0 +1,57 @@
+package ru.hutoroff.jagpb.bot.commands.implementation;
+
+import org.apache.commons.cli.*;
+import ru.hutoroff.jagpb.bot.commands.Command;
+import ru.hutoroff.jagpb.bot.commands.CommandType;
+import ru.hutoroff.jagpb.bot.commands.Help;
+import ru.hutoroff.jagpb.bot.exceptions.UnknownOptionsException;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public class LastPollResultCommand extends Command {
+	private static final Options options = new Options();
+	private static final CommandLineParser cliParser = new DefaultParser();
+	private static final String HELP;
+	private static final String COMMAND_SYNTAX = "/lastPollResult [-c CHAT_ID]";
+
+	static {
+		options.addOption(Option.builder("c")
+				.longOpt("chat")
+				.hasArg()
+				.optionalArg(false)
+				.argName("CHAT_ID")
+				.desc("id of chat to get last poll for")
+				.numberOfArgs(1)
+				.required(false)
+				.build()
+		);
+
+		StringWriter sw = new StringWriter();
+		PrintWriter pw = new PrintWriter(sw);
+		HelpFormatter helpFormatter = new HelpFormatter();
+		helpFormatter.printHelp(pw, HelpFormatter.DEFAULT_WIDTH, COMMAND_SYNTAX, null, options, 3, 0, null);
+		HELP = sw.toString();
+	}
+
+	public LastPollResultCommand(String[] arguments) throws UnknownOptionsException {
+		super(CommandType.LAST_POLL_RESULT, arguments);
+	}
+
+	@Override
+	public String getHelp() {
+		return Help.LAST_POLL;
+	}
+
+	@Override
+	protected CommandLine initArguments(String[] split) throws UnknownOptionsException {
+		try {
+			if (split == null || split.length == 0) {
+				return cliParser.parse(options, new String[0]);
+			}
+			return cliParser.parse(options, split);
+		} catch (ParseException e) {
+			throw new UnknownOptionsException(HELP, e);
+		}
+	}
+}

--- a/src/main/java/ru/hutoroff/jagpb/bot/commands/implementation/StartCommand.java
+++ b/src/main/java/ru/hutoroff/jagpb/bot/commands/implementation/StartCommand.java
@@ -1,6 +1,9 @@
-package ru.hutoroff.jagpb.bot.commands;
+package ru.hutoroff.jagpb.bot.commands.implementation;
 
 import org.apache.commons.cli.CommandLine;
+import ru.hutoroff.jagpb.bot.commands.Command;
+import ru.hutoroff.jagpb.bot.commands.CommandType;
+import ru.hutoroff.jagpb.bot.commands.Help;
 import ru.hutoroff.jagpb.bot.exceptions.UnknownOptionsException;
 
 public class StartCommand extends Command {

--- a/src/main/java/ru/hutoroff/jagpb/business/PollService.java
+++ b/src/main/java/ru/hutoroff/jagpb/business/PollService.java
@@ -25,8 +25,8 @@ public class PollService {
         this.pollDAO = pollDAO;
     }
 
-    public PollDO createAndGetBackPoll(String title, List<PollOption> options, Integer authorId) {
-        ObjectId id = this.createPoll(title, options, authorId);
+    public PollDO createAndGetBackPoll(String title, List<PollOption> options, Integer authorId, Long chatId) {
+        ObjectId id = this.createPoll(title, options, authorId, chatId);
         return this.getPoll(id);
     }
 
@@ -60,10 +60,15 @@ public class PollService {
         return true;
     }
 
-    private ObjectId createPoll(String title, List<PollOption> options, Integer authorId) {
+    public PollDO getLastPollForUserInChat(final Integer userId, final Long chatId) {
+        return pollDAO.getLastPollByAuthorInChat(userId, chatId);
+    }
+
+    private ObjectId createPoll(String title, List<PollOption> options, Integer authorId, Long chatId) {
         PollDO newPoll = new PollDO();
 
         newPoll.setAuthorId(authorId);
+        newPoll.setChatId(chatId);
         newPoll.setTitle(title);
         newPoll.setOptions(options);
 

--- a/src/main/java/ru/hutoroff/jagpb/data/model/PollDO.java
+++ b/src/main/java/ru/hutoroff/jagpb/data/model/PollDO.java
@@ -16,6 +16,9 @@ public class PollDO extends BaseMongoDO implements PollDocument {
     @Property(F_AUTHOR)
     private Integer authorId;
 
+    @Property(F_CHAT)
+    private Long chatId;
+
     @Property(F_CREATED)
     private Date created;
 
@@ -40,6 +43,14 @@ public class PollDO extends BaseMongoDO implements PollDocument {
 
     public void setAuthorId(Integer authorId) {
         this.authorId = authorId;
+    }
+
+    public Long getChatId() {
+        return chatId;
+    }
+
+    public void setChatId(Long chatId) {
+        this.chatId = chatId;
     }
 
     public Date getCreated() {

--- a/src/main/java/ru/hutoroff/jagpb/data/mongo/dao/PollDAO.java
+++ b/src/main/java/ru/hutoroff/jagpb/data/mongo/dao/PollDAO.java
@@ -3,6 +3,7 @@ package ru.hutoroff.jagpb.data.mongo.dao;
 import org.bson.types.ObjectId;
 import org.mongodb.morphia.Datastore;
 import org.mongodb.morphia.dao.BasicDAO;
+import org.mongodb.morphia.query.FindOptions;
 import org.mongodb.morphia.query.Query;
 import org.mongodb.morphia.query.UpdateOperations;
 import org.mongodb.morphia.query.UpdateResults;
@@ -20,6 +21,14 @@ public class PollDAO extends BasicDAO<PollDO, ObjectId> implements PollDocument 
     @Autowired
     public PollDAO(Datastore ds) {
         super(ds);
+    }
+
+    public PollDO getLastPollByAuthorInChat(Integer authorId, Long chatId) {
+        Query<PollDO> query = getDatastore().createQuery(PollDO.class)
+                .field(F_AUTHOR).equal(authorId)
+                .field(F_CHAT).equal(chatId)
+                .order("-" + F_CREATED);
+        return query.get(new FindOptions().limit(1));
     }
 
     public List<PollDO> getPollsCreatedBy(String authorId) {

--- a/src/main/java/ru/hutoroff/jagpb/data/mongo/dao/PollDocument.java
+++ b/src/main/java/ru/hutoroff/jagpb/data/mongo/dao/PollDocument.java
@@ -2,6 +2,7 @@ package ru.hutoroff.jagpb.data.mongo.dao;
 
 public interface PollDocument extends MongoDocument {
     String F_AUTHOR = "author";
+    String F_CHAT = "chat";
     String F_TITLE = "title";
     String F_CREATED = "created";
     String F_OPTIONS = "options";


### PR DESCRIPTION
Implemented command /lastPollResult

Command syntax:
```
/lastPollResult [-c "CHAT_ID"]
CHAT_ID - id of chat where poll was created by current user. If not provided will be used id of chat where command was sent
```
This resolves #4 