### PR TITLE
Errors on basic operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,8 @@ jdk:
 - oraclejdk8
 sudo: false
 script: mvn clean verify
+
+notifications:
+  email:
+    on_success: change
+    on_failure: always

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,11 @@
       <artifactId>logback-classic</artifactId>
       <version>1.2.3</version>
     </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <version>1.2.3</version>
+    </dependency>
 
     <!-- Spring -->
     <dependency>

--- a/src/main/java/ru/hutoroff/jagpb/bot/PollingBot.java
+++ b/src/main/java/ru/hutoroff/jagpb/bot/PollingBot.java
@@ -123,7 +123,7 @@ public class PollingBot extends TelegramLongPollingBot {
                 return;
             case LAST_POLL_RESULT:
                 String chatIdCmd = command.getArguments().getOptionValue('c');
-                Long chatIdActual = StringUtils.isNumeric(chatIdCmd.replaceAll("-", "")) ? Long.valueOf(chatIdCmd) : chatId;
+                Long chatIdActual = (chatIdCmd != null && StringUtils.isNumeric(chatIdCmd.replaceAll("-", ""))) ? Long.valueOf(chatIdCmd) : chatId;
                 PollDO pollToReport = pollService.getLastPollForUserInChat(message.getFrom().getId(), chatIdActual);
                 if (pollToReport != null) {
                     doSimpleReply(chatId, PollInfoBuilder.preparePollingReport(pollToReport));

--- a/src/main/java/ru/hutoroff/jagpb/bot/PollingBot.java
+++ b/src/main/java/ru/hutoroff/jagpb/bot/PollingBot.java
@@ -72,7 +72,7 @@ public class PollingBot extends TelegramLongPollingBot {
                     .setChatId(update.getCallbackQuery().getMessage().getChatId())
                     .setMessageId(update.getCallbackQuery().getMessage().getMessageId())
                     .setText(PollInfoBuilder.prepareText(poll));
-            editMessageText.setParseMode(ParseMode.MARKDOWN);
+            editMessageText.setParseMode(ParseMode.HTML);
             editMessageText.setReplyMarkup(PollInfoBuilder.prepareKeybaord(poll.getOptions(), pollId.toString()));
             try {
                 execute(editMessageText);
@@ -114,7 +114,7 @@ public class PollingBot extends TelegramLongPollingBot {
                 final List<PollOption> pollOptions = Arrays.stream(options).map(el -> new PollOption(StringUtils.strip(el, "\""))).collect(Collectors.toList());
                 PollDO createdPoll = pollService.createAndGetBackPoll(pollTitle, pollOptions, authorId, chatId);
                 SendMessage sendMessage = PollInfoBuilder.buildPollMessage(createdPoll, chatId);
-                sendMessage.setParseMode(ParseMode.MARKDOWN);
+                sendMessage.setParseMode(ParseMode.HTML);
 
                 sendReply(sendMessage);
                 return;
@@ -163,7 +163,7 @@ public class PollingBot extends TelegramLongPollingBot {
 
     private void doSimpleReply(Long chatId, String replyText) {
         SendMessage reply = new SendMessage(chatId, replyText);
-        reply.setParseMode(ParseMode.MARKDOWN);
+        reply.setParseMode(ParseMode.HTML);
         this.sendReply(reply);
     }
 

--- a/src/main/java/ru/hutoroff/jagpb/bot/commands/Help.java
+++ b/src/main/java/ru/hutoroff/jagpb/bot/commands/Help.java
@@ -5,7 +5,7 @@ public class Help {
 	public static final String COMMAND_HELP_COMMAND = "usage: /commandhelp COMMAND";
 	public static final String CREATE_POLL_COMMAND = "usage: /create -t \"Poll Title\" -o {\"option1\",\"option2\",...,\"optionN\"}";
 	public static final String HELP = "usage: /help";
-	public static final String LAST_POLL = "usage: /lastpollresult [[-c \"CHAT_ID\"]]";
+	public static final String LAST_POLL = "usage: /lastpollresult [-c \"CHAT_ID\"]";
 	public static final String START_COMMAND = "usage: /start";
 
 }

--- a/src/main/java/ru/hutoroff/jagpb/bot/messages/PollInfoBuilder.java
+++ b/src/main/java/ru/hutoroff/jagpb/bot/messages/PollInfoBuilder.java
@@ -19,13 +19,13 @@ public class PollInfoBuilder {
 	private static final String MALE_SHRUG = EmojiManager.getForAlias("male_shrug").getUnicode();
 
 	private static final String HEADER_FORMAT = EmojiManager.getForAlias("bar_chart").getUnicode() + " %s\n";
-	private static final String OPTION_FORMAT = "\n*%s* - _%d_";
+	private static final String OPTION_FORMAT = "\n<b>%s</b> - <i>%d</i>";
 	private static final String VOTER_FORMAT = "\n\t" + BOX_UP_AND_RIGHT + EmojiManager.getForAlias("bust_in_silhouette").getUnicode() +  " %s%s";
 	private static final String VOTED_N_TOTAL_FORMAT = "\n" + EmojiManager.getForAlias("clipboard").getUnicode() + " %d voted";
 	private static final String VOTED_EMPTY_TOTAL_FORMAT = "\n" + EmojiManager.getForAlias("clipboard").getUnicode() + " nobody voted";
 
-	private static final String REPORT_VOTED_TITLE_FORMAT = "Poll *%s*:\n";
-	private static final String REPORT_VOTED_OPTION_FORMAT = "\n*%s* voted (%d): %s";
+	private static final String REPORT_VOTED_TITLE_FORMAT = "Poll <b>%s</b>:\n";
+	private static final String REPORT_VOTED_OPTION_FORMAT = "\n<b>%s</b> voted (%d): %s";
 	private static final String REPORT_VOTED_TOTAL_FORMAT = "\n\nTotal voted: %d";
 
 	public static SendMessage buildPollMessage(PollDO poll, Long chatId) {

--- a/src/main/java/ru/hutoroff/jagpb/data/model/PollOption.java
+++ b/src/main/java/ru/hutoroff/jagpb/data/model/PollOption.java
@@ -21,12 +21,12 @@ public class PollOption implements PollDocument {
     private Set<Voter> voters;
 
     public PollOption() {
-        this.id = RandomStringUtils.random(8);
+        this.id = RandomStringUtils.randomNumeric(8);
         this.voters = new HashSet<>();
     }
 
     public PollOption(String title) {
-        this.id = RandomStringUtils.random(8);
+        this.id = RandomStringUtils.randomNumeric(8);
         this.title = title;
     }
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -4,7 +4,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern><![CDATA[MID:%mdc{ID_MEGA} %-5p [%logger{0}:%M:%L] %message%throwable%n]]></pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n\</pattern>
         </encoder>
     </appender>
 
@@ -25,7 +25,6 @@
     </logger>
 
     <root level="info">
-        <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE"/>
     </root>
 </configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,13 +1,31 @@
 <configuration debug="false">
+    <timestamp key="byDay" datePattern="yyyyMMdd'T'HHmmss"/>
+    <property name="PATH" value="./logs"/>
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern><![CDATA[MID:%mdc{ID_MEGA} %-5p [%logger{0}:%M:%L] %message%throwable%n]]></pattern>
         </encoder>
     </appender>
 
-    <logger name="debugger" level="DEBUG"/>
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${PATH}/jagpb.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${PATH}/jagpb.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>7</maxHistory>
+            <totalSizeCap>2gb</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
 
-    <root level="INFO">
+    <logger name="ru.hutoroff.jagpb" level="DEBUG">
         <appender-ref ref="STDOUT" />
+    </logger>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="FILE"/>
     </root>
 </configuration>


### PR DESCRIPTION
Errors were caused by issues with message markdown. Decided to use html instead of markdown.
Logging improved.
Fixed TravisCI notifications policy: email notifications are sent only when build failed, or succeed after failure.
This resolves #10 